### PR TITLE
Fix cover entity icons

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -4658,7 +4658,7 @@ function getEntityIcon(entity) {
             return state === 'on' ? 'images/icon_switch_on.png' : 'images/icon_switch_off.png';
 
         case 'cover':
-            return state === 'open' ? 'images/icon_blind_open.png' : 'images/icon_blind_closed.png';
+            return state === 'open' ? 'images/icon_blinds_open.png' : 'images/icon_blinds_closed.png';
 
         case 'lock':
             return state === 'locked' ? 'images/icon_locked.png' : 'images/icon_unlocked.png';


### PR DESCRIPTION
Right now, cover entities try to load their icons with an incorrect file name. This fixes those filenames in code, so we no-longer look for non-existent files.

Solves #25 