### PR TITLE
Fix mismatched package name for Android Stack translation

### DIFF
--- a/src/js/lib/safe.js
+++ b/src/js/lib/safe.js
@@ -91,7 +91,7 @@ safe.translateStack = function(stack, level) {
   level = level || 0;
   if (Pebble.platform === 'pypkjs') {
     return safe.translateStackV8(stack, level);
-  } else if (stack.match('com.getpebble.android')) {
+  } else if (stack.match('com.getpebble.android') || stack.match('coredevices.coreapp')) {
     return safe.translateStackAndroid(stack, level);
   } else {
     return safe.translateStackIOS(stack, level);


### PR DESCRIPTION
The new Pebble app is in beta, and it uses a new package name: `coredevices.coreapp`. If a stack trace gets printed to the log, and you're using the new app, we mistakenly call `translateStackIOS` instead of `translateStackAndroid` because of the mismatched package name.

This change checks for both the old package name and the new one.

Solves #27 