### PR TITLE
Next release v2.1

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -196,7 +196,7 @@
   ],
   "uuid": "61ae3254-ce00-49db-aad8-23143f649b90",
   "versionCode": 1,
-  "versionLabel": "2.0",
+  "versionLabel": "2.1",
   "watchapp": {
     "hiddenApp": false,
     "watchface": false

--- a/config/v1.2.html
+++ b/config/v1.2.html
@@ -738,6 +738,20 @@
 			</div>
 		</div>
 
+		<!-- Display Settings -->
+		<div class="section">
+			<div class="section-header">Display Settings</div>
+			<div class="section-body">
+				<div class="component">
+					<div class="form-switch">
+						<label class="form-check-label" for="ha-menu-scroll-wrap">Menu Scrolling - Wrap Around</label>
+						<input class="form-check-input" type="checkbox" id="ha-menu-scroll-wrap" checked>
+					</div>
+					<small class="form-text">When enabled, scrolling past the top or bottom of a menu jumps to the other end</small>
+				</div>
+			</div>
+		</div>
+
 		<!-- Quick Launch Settings -->
 		<div class="section">
 			<div class="section-header">Quick Launch Settings</div>
@@ -1219,6 +1233,7 @@
 				quickLaunchFavoriteEntity = $('#ha-quick-launch-favorite-entity'),
 				quickLaunchFavoriteEntityContainer = $('#quick-launch-favorite-entity-container'),
 				quickLaunchExitOnBack = $('#ha-quick-launch-exit-on-back'),
+				menuScrollWrap = $('#ha-menu-scroll-wrap'),
 				unavailableHandling = $('#ha-unavailable-handling'),
 				unknownHandling = $('#ha-unknown-handling'),
 				automationLongpress = $('#ha-automation-longpress'),
@@ -1267,6 +1282,7 @@
 				'quick_launch_behavior': quickLaunchBehavior.val(),
 				'quick_launch_favorite_entity': quickLaunchFavoriteEntity.val() || null,
 				'quick_launch_exit_on_back': quickLaunchExitOnBack.is(':checked'),
+				'menu_scroll_wrap': menuScrollWrap.is(':checked'),
 				// Domain menu settings
 				'domain_menu_enabled': 'conditional', // Default global setting
 				'domain_menu_all_entities': domainMenuAll.val(),
@@ -1454,6 +1470,9 @@
 			} else {
 				quickLaunchExitOnBack.prop('checked', false);
 			}
+
+			// Handle menu scroll wrap-around (default enabled)
+			menuScrollWrap.prop('checked', typeof watch_config['menu_scroll_wrap'] !== 'undefined' ? watch_config['menu_scroll_wrap'] : true);
 
 			// Handle domain menu settings
 			if (watch_config['domain_menu_all_entities']) {

--- a/config/v1.2.html
+++ b/config/v1.2.html
@@ -749,6 +749,13 @@
 					</div>
 					<small class="form-text">When enabled, scrolling past the top or bottom of a menu jumps to the other end</small>
 				</div>
+				<div class="component">
+					<div class="form-group">
+						<label class="form-label" for="ha-inactivity-timeout">Inactivity Timeout (seconds)</label>
+						<input type="number" class="form-control" id="ha-inactivity-timeout" min="0" step="1" value="0">
+						<small class="form-text">Exit the app after this many seconds without any button presses or navigation on the watch. Set to 0 to disable. Also configurable on the watch under Settings.</small>
+					</div>
+				</div>
 			</div>
 		</div>
 
@@ -1234,6 +1241,7 @@
 				quickLaunchFavoriteEntityContainer = $('#quick-launch-favorite-entity-container'),
 				quickLaunchExitOnBack = $('#ha-quick-launch-exit-on-back'),
 				menuScrollWrap = $('#ha-menu-scroll-wrap'),
+				inactivityTimeout = $('#ha-inactivity-timeout'),
 				unavailableHandling = $('#ha-unavailable-handling'),
 				unknownHandling = $('#ha-unknown-handling'),
 				automationLongpress = $('#ha-automation-longpress'),
@@ -1283,6 +1291,7 @@
 				'quick_launch_favorite_entity': quickLaunchFavoriteEntity.val() || null,
 				'quick_launch_exit_on_back': quickLaunchExitOnBack.is(':checked'),
 				'menu_scroll_wrap': menuScrollWrap.is(':checked'),
+				'inactivity_timeout': parseInt(inactivityTimeout.val(), 10) || 0,
 				// Domain menu settings
 				'domain_menu_enabled': 'conditional', // Default global setting
 				'domain_menu_all_entities': domainMenuAll.val(),
@@ -1473,6 +1482,9 @@
 
 			// Handle menu scroll wrap-around (default enabled)
 			menuScrollWrap.prop('checked', typeof watch_config['menu_scroll_wrap'] !== 'undefined' ? watch_config['menu_scroll_wrap'] : true);
+
+			// Handle inactivity timeout (default 0 = disabled)
+			inactivityTimeout.val(typeof watch_config['inactivity_timeout'] !== 'undefined' ? watch_config['inactivity_timeout'] : 0);
 
 			// Handle domain menu settings
 			if (watch_config['domain_menu_all_entities']) {

--- a/src/js/app/AppState.js
+++ b/src/js/app/AppState.js
@@ -28,6 +28,7 @@ class AppState {
         this.quick_launch_behavior = 'main_menu';
         this.quick_launch_favorite_entity = null;
         this.quick_launch_exit_on_back = false;
+        this.inactivity_timeout = 0;
         this.domain_menu_enabled = 'conditional';
         this.domain_menu_all_entities = 'conditional';
         this.domain_menu_areas = 'conditional';

--- a/src/js/app/Constants.js
+++ b/src/js/app/Constants.js
@@ -5,7 +5,7 @@ const Feature = require('platform/feature');
 
 const Constants = {
     // App versioning
-    appVersion: '2.0',
+    appVersion: '2.1',
     confVersion: '1.2',
     configPageUrl: 'https://skylord123.github.io/pebble-home-assistant-ws/config/v1.2.html',
 

--- a/src/js/app/EntityService.js
+++ b/src/js/app/EntityService.js
@@ -201,6 +201,9 @@ var EntityService = {
             case 'fan':
                 require('app/pages/entity/FanPage').showFanEntity(entity_id);
                 break;
+            case 'cover':
+                require('app/pages/entity/CoverPage').showCoverEntity(entity_id);
+                break;
             default:
                 require('app/pages/entity/GenericEntityPage').showEntityMenu(entity_id);
                 break;

--- a/src/js/app/EntityService.js
+++ b/src/js/app/EntityService.js
@@ -280,7 +280,7 @@ var EntityService = {
         } else if (domain === "scene") {
             appState.haws.callService(
                 domain,
-                "apply",
+                "turn_on",
                 {},
                 { entity_id: entity_id },
                 function(data) {

--- a/src/js/app/EntityService.js
+++ b/src/js/app/EntityService.js
@@ -327,6 +327,21 @@ var EntityService = {
             } else {
                 log('Vacuum ' + entity_id + ' in state ' + state + ' - no action taken');
             }
+        } else if (domain === "button" || domain === "input_button") {
+            appState.haws.callService(
+                domain,
+                'press',
+                {},
+                { entity_id: entity_id },
+                function(data) {
+                    log(JSON.stringify(data));
+                    Vibe.vibrate('short');
+                },
+                function(error) {
+                    log('no response');
+                    Vibe.vibrate('double');
+                }
+            );
         }
     },
 

--- a/src/js/app/EntityService.js
+++ b/src/js/app/EntityService.js
@@ -63,6 +63,7 @@ var EntityService = {
 
             case 'switch':
             case 'input_boolean':
+            case 'fan':
                 return state === 'on' ? 'images/icon_switch_on.png' : 'images/icon_switch_off.png';
 
             case 'cover':
@@ -197,6 +198,9 @@ var EntityService = {
             case 'climate':
                 require('app/pages/entity/ClimatePage').showClimateEntity(entity_id);
                 break;
+            case 'fan':
+                require('app/pages/entity/FanPage').showFanEntity(entity_id);
+                break;
             default:
                 require('app/pages/entity/GenericEntityPage').showEntityMenu(entity_id);
                 break;
@@ -239,6 +243,7 @@ var EntityService = {
         } else if (
             domain === "switch" ||
             domain === "light" ||
+            domain === "fan" ||
             domain === "input_boolean" ||
             domain === "script" ||
             domain === "cover"

--- a/src/js/app/SettingsManager.js
+++ b/src/js/app/SettingsManager.js
@@ -3,6 +3,7 @@
  */
 var Settings = require('settings');
 var Feature = require('platform/feature');
+var Menu = require('ui/menu');
 var AppState = require('app/AppState');
 var Constants = require('app/Constants');
 var helpers = require('app/helpers');
@@ -104,6 +105,11 @@ var SettingsManager = {
         log('Entity handling - unavailable: ' + appState.unavailable_entity_handling +
             ', unknown: ' + appState.unknown_entity_handling);
         log('Automation long-press action: ' + appState.automation_longpress_action);
+
+        // Menu scrolling wrap-around setting (default enabled)
+        appState.menu_scroll_wrap = Settings.option('menu_scroll_wrap') !== false;
+        Menu.setScrollWrapDefault(appState.menu_scroll_wrap);
+        log('Menu scroll wrap-around: ' + appState.menu_scroll_wrap);
 
         // Main menu ordering settings
         appState.main_menu_custom_order_enabled = Settings.option('main_menu_custom_order_enabled') === true;

--- a/src/js/app/SettingsManager.js
+++ b/src/js/app/SettingsManager.js
@@ -177,17 +177,23 @@ var SettingsManager = {
         },
         function(e) {
             log('closed configurable');
-            log('returned_settings: ' + JSON.stringify(e.options));
-            Settings.option(e.options);
 
+            // Android fires an extra "cancelled" webviewclosed event after a
+            // normal close, and the user can also genuinely cancel. In both
+            // cases the underlying options weren't touched, so we must not
+            // reload or restart — doing so during a flaky connection just
+            // adds churn.
             if (e.failed) {
-                log(e.response);
+                log('Config close failed/cancelled, ignoring: ' + e.response);
+                return;
             }
 
-            // Reload settings
+            log('returned_settings: ' + JSON.stringify(e.options));
+            // Settings.onCloseConfig has already merged and persisted the new
+            // options via autoSave, so no second Settings.option() call here.
+
             self.load();
 
-            // Call the callback if provided
             if (options.onSettingsChanged) {
                 options.onSettingsChanged();
             }

--- a/src/js/app/SettingsManager.js
+++ b/src/js/app/SettingsManager.js
@@ -4,6 +4,7 @@
 var Settings = require('settings');
 var Feature = require('platform/feature');
 var Menu = require('ui/menu');
+var InactivityTimer = require('app/InactivityTimer');
 var AppState = require('app/AppState');
 var Constants = require('app/Constants');
 var helpers = require('app/helpers');
@@ -105,6 +106,11 @@ var SettingsManager = {
         log('Entity handling - unavailable: ' + appState.unavailable_entity_handling +
             ', unknown: ' + appState.unknown_entity_handling);
         log('Automation long-press action: ' + appState.automation_longpress_action);
+
+        // Inactivity timeout in seconds (0 = disabled). Configuring it also
+        // (re)starts the countdown, so a settings change applies immediately.
+        appState.inactivity_timeout = parseInt(Settings.option('inactivity_timeout'), 10) || 0;
+        InactivityTimer.configure(appState.inactivity_timeout);
 
         // Menu scrolling wrap-around setting (default enabled)
         appState.menu_scroll_wrap = Settings.option('menu_scroll_wrap') !== false;

--- a/src/js/app/pages/EntityListPage.js
+++ b/src/js/app/pages/EntityListPage.js
@@ -238,17 +238,20 @@ class EntityListPage extends BasePage {
                 self.relativeTimeUpdater.clear();
             }
 
-            self.menu.items(0, []); // clear items
-            var menuIndex = 0;
+            // Build the full item list first and submit it in a single
+            // items() call. This sends one section update carrying the final
+            // item count ahead of the item stream, so the watch knows the
+            // true list length immediately (needed for wrap-around scrolling
+            // to jump to the real end while items are still transferring).
+            var menuItems = [];
 
             if (pageNumber > 1) {
-                self.menu.item(0, menuIndex, {
+                menuItems.push({
                     title: "Prev Page",
                     on_click: function(e) {
                         self.updateStates(pageNumber - 1);
                     }
                 });
-                menuIndex++;
             }
 
             helpers.log_message('renderMenu: about to render ' + data.length + ' items to menu');
@@ -259,7 +262,6 @@ class EntityListPage extends BasePage {
                         continue;
                     }
 
-                    var menuId = menuIndex++;
                     var itemTitle = data[j].attributes.friendly_name ? data[j].attributes.friendly_name : data[j].entity_id;
                     var itemSubtitle = data[j].state + (data[j].attributes.unit_of_measurement ? ' ' + data[j].attributes.unit_of_measurement : '') + ' > ' + helpers.humanDiff(new Date(), new Date(data[j].last_changed));
 
@@ -272,13 +274,13 @@ class EntityListPage extends BasePage {
                         itemIcon = 'images/icon_unknown.png';
                     }
 
-                    self.menu.item(0, menuId, {
+                    renderedEntityIds[data[j].entity_id] = menuItems.length;
+                    menuItems.push({
                         title: itemTitle,
                         subtitle: itemSubtitle,
                         entity_id: data[j].entity_id,
                         icon: itemIcon
                     });
-                    renderedEntityIds[data[j].entity_id] = menuId;
 
                     // Register entity for relative time updates
                     if (self.relativeTimeUpdater) {
@@ -288,15 +290,24 @@ class EntityListPage extends BasePage {
                     helpers.log_message('renderMenu: ERROR rendering entity ' + (data[j] ? data[j].entity_id : 'unknown') + ' at index ' + j + ': ' + err.message);
                 }
             }
-            helpers.log_message('renderMenu: rendered ' + menuIndex + ' items total');
+            helpers.log_message('renderMenu: rendered ' + menuItems.length + ' items total');
 
             if (paginateMore) {
-                self.menu.item(0, menuIndex, {
+                menuItems.push({
                     title: "Next Page",
                     on_click: function(e) {
                         self.updateStates(pageNumber + 1);
                     }
                 });
+            }
+
+            self.menu.items(0, menuItems);
+
+            // Reset selection to the top when switching pagination pages, but
+            // not on same-page re-renders (returning from a detail page or
+            // live entity updates), where the selection should stay put
+            if (self.currentPage !== null && self.currentPage !== pageNumber) {
+                self.menu.selection(0, 0);
             }
 
             self.currentPage = pageNumber;
@@ -459,12 +470,13 @@ function showEntityDomainsFromList(entityIdList, title) {
             helpers.log_message('showEntityDomainsFromList: domain \'' + d + '\' has ' + domainEntities[d].length + ' entities');
         }
 
-        // Add domain entries into menu
-        var menuIdx = 0;
+        // Add domain entries into menu with a single items() call so the
+        // final item count reaches the watch ahead of the item stream
+        var domainMenuItems = [];
         for (var domainName in domainEntities) {
             (function(dom, entities) {
                 var displayName = helpers.ucwords(dom.replace('_', ' '));
-                domainListMenu.item(0, menuIdx++, {
+                domainMenuItems.push({
                     title: displayName,
                     subtitle: entities.length + ' ' + (entities.length > 1 ? 'entities' : 'entity'),
                     on_click: function(e) {
@@ -474,6 +486,7 @@ function showEntityDomainsFromList(entityIdList, title) {
                 });
             })(domainName, domainEntities[domainName]);
         }
+        domainListMenu.items(0, domainMenuItems);
     });
 
     domainListMenu.on('select', function(e) {

--- a/src/js/app/pages/SettingsMenuPage.js
+++ b/src/js/app/pages/SettingsMenuPage.js
@@ -9,6 +9,7 @@ var BasePage = require('app/pages/BasePage');
 var AppState = require('app/AppState');
 var Constants = require('app/Constants');
 var helpers = require('app/helpers');
+var InactivityTimer = require('app/InactivityTimer');
 
 class SettingsMenuPage extends BasePage {
     constructor() {
@@ -65,6 +66,14 @@ class SettingsMenuPage extends BasePage {
             title: "Quick Launch",
             on_click: function(e) {
                 showQuickLaunchSettings();
+            }
+        });
+
+        this.menu.item(0, i++, {
+            title: "Inactivity Timeout",
+            subtitle: formatInactivityTimeout(appState.inactivity_timeout),
+            on_click: function(e) {
+                showInactivityTimeoutMenu();
             }
         });
     }
@@ -533,6 +542,93 @@ function showAutomationLongpressMenu() {
     });
 
     automationMenu.show();
+}
+
+var INACTIVITY_TIMEOUT_PRESETS = [
+    { label: 'Disabled', seconds: 0 },
+    { label: '30 seconds', seconds: 30 },
+    { label: '1 minute', seconds: 60 },
+    { label: '2 minutes', seconds: 120 },
+    { label: '5 minutes', seconds: 300 },
+    { label: '10 minutes', seconds: 600 },
+    { label: '15 minutes', seconds: 900 },
+    { label: '30 minutes', seconds: 1800 },
+    { label: '1 hour', seconds: 3600 }
+];
+
+function formatInactivityTimeout(seconds) {
+    if (!seconds || seconds <= 0) {
+        return 'Disabled';
+    }
+    if (seconds < 60) {
+        return seconds + 's';
+    }
+    if (seconds % 3600 === 0) {
+        return (seconds / 3600) + 'h';
+    }
+    if (seconds % 60 === 0) {
+        return (seconds / 60) + 'm';
+    }
+    return Math.floor(seconds / 60) + 'm ' + (seconds % 60) + 's';
+}
+
+function showInactivityTimeoutMenu() {
+    var appState = AppState.getInstance();
+
+    var timeoutMenu = new UI.Menu({
+        status: false,
+        backgroundColor: 'black',
+        textColor: 'white',
+        highlightBackgroundColor: 'white',
+        highlightTextColor: 'black',
+        sections: [{
+            title: 'Inactivity Timeout'
+        }]
+    });
+
+    function updateMenuItems() {
+        var items = [];
+        var isPreset = false;
+
+        for (var i = 0; i < INACTIVITY_TIMEOUT_PRESETS.length; i++) {
+            var preset = INACTIVITY_TIMEOUT_PRESETS[i];
+            var isCurrent = appState.inactivity_timeout === preset.seconds;
+            if (isCurrent) {
+                isPreset = true;
+            }
+            items.push({
+                title: preset.label,
+                subtitle: isCurrent ? 'Current' : '',
+                value: preset.seconds
+            });
+        }
+
+        // A custom value set from the config page may not match any preset;
+        // show it so the current setting is always visible
+        if (!isPreset) {
+            items.push({
+                title: formatInactivityTimeout(appState.inactivity_timeout),
+                subtitle: 'Current (custom)',
+                value: appState.inactivity_timeout
+            });
+        }
+
+        timeoutMenu.items(0, items);
+    }
+
+    timeoutMenu.on('show', updateMenuItems);
+
+    timeoutMenu.on('select', function(e) {
+        appState.inactivity_timeout = e.item.value;
+        Settings.option('inactivity_timeout', appState.inactivity_timeout);
+        InactivityTimer.configure(appState.inactivity_timeout);
+        updateMenuItems();
+        setTimeout(function() {
+            timeoutMenu.hide();
+        }, 500);
+    });
+
+    timeoutMenu.show();
 }
 
 /**

--- a/src/js/app/pages/ToDoListPage.js
+++ b/src/js/app/pages/ToDoListPage.js
@@ -268,62 +268,37 @@ function showToDoList(entity_id) {
             }
         });
 
-        // Clear existing items in all sections
-        todoListMenu.items(0, []);
-        todoListMenu.items(1, []);
+        // Helper to build a menu item for a to-do item
+        function buildToDoMenuItem(item) {
+            let subtitle = '';
+
+            // Priority: description > due date > empty
+            if (item.description) {
+                subtitle = item.description;
+            } else if (item.due) {
+                subtitle = `Due: ${item.due}`;
+            }
+
+            return {
+                title: item.summary,
+                subtitle: subtitle || '',
+                uid: item.uid,
+                status: item.status,
+                description: item.description,
+                due: item.due,
+                on_click: function(e) {
+                    helpers.log_message(`Todo item clicked: ${item.summary} (${item.uid})`);
+                    // TODO: Show item details or actions menu
+                    showToDoItemMenu(entity_id, item);
+                }
+            };
+        }
+
+        // Submit each section as a single items() call so the watch gets the
+        // final section counts ahead of the item stream
+        todoListMenu.items(0, incompleteItems.map(buildToDoMenuItem));
+        todoListMenu.items(1, completedItems.map(buildToDoMenuItem));
         todoListMenu.items(2, []);
-
-        // Add incomplete items to section 0
-        incompleteItems.forEach(function(item, index) {
-            let subtitle = '';
-
-            // Priority: description > due date > empty
-            if (item.description) {
-                subtitle = item.description;
-            } else if (item.due) {
-                subtitle = `Due: ${item.due}`;
-            }
-
-            todoListMenu.item(0, index, {
-                title: item.summary,
-                subtitle: subtitle || '',
-                uid: item.uid,
-                status: item.status,
-                description: item.description,
-                due: item.due,
-                on_click: function(e) {
-                    helpers.log_message(`Todo item clicked: ${item.summary} (${item.uid})`);
-                    // TODO: Show item details or actions menu
-                    showToDoItemMenu(entity_id, item);
-                }
-            });
-        });
-
-        // Add completed items to section 1
-        completedItems.forEach(function(item, index) {
-            let subtitle = '';
-
-            // Priority: description > due date > empty
-            if (item.description) {
-                subtitle = item.description;
-            } else if (item.due) {
-                subtitle = `Due: ${item.due}`;
-            }
-
-            todoListMenu.item(1, index, {
-                title: item.summary,
-                subtitle: subtitle || '',
-                uid: item.uid,
-                status: item.status,
-                description: item.description,
-                due: item.due,
-                on_click: function(e) {
-                    helpers.log_message(`Todo item clicked: ${item.summary} (${item.uid})`);
-                    // TODO: Show item details or actions menu
-                    showToDoItemMenu(entity_id, item);
-                }
-            });
-        });
 
         // Add action items to section 2
         let actionIndex = 0;

--- a/src/js/app/pages/entity/FanPage.js
+++ b/src/js/app/pages/entity/FanPage.js
@@ -1,0 +1,557 @@
+/**
+ * FanPage - Fan entity control page
+ *
+ * Features:
+ * - On/off toggle
+ * - Speed (percentage) control with slider
+ * - Preset mode selection
+ * - Oscillation toggle
+ * - Direction toggle
+ * - Real-time state subscription
+ */
+var UI = require('ui');
+var Vector = require('vector2');
+var Feature = require('platform/feature');
+var Vibe = require('ui/vibe');
+
+var BaseEntityPage = require('app/pages/entity/BaseEntityPage');
+var AppState = require('app/AppState');
+var helpers = require('app/helpers');
+var RelativeTimeUpdater = require('app/RelativeTimeUpdater');
+
+// Menu selection tracking
+var menuSelections = {
+    fanMenu: 0
+};
+
+var GenericEntityPage = require('app/pages/entity/GenericEntityPage');
+
+function showFanEntity(entity_id) {
+    var appState = AppState.getInstance();
+    let fan = appState.ha_state_dict[entity_id],
+        subscription_msg_id = null,
+        relativeTimeUpdater = null;
+    if (!fan) {
+        throw new Error(`Fan entity ${entity_id} not found in appState.ha_state_dict`);
+    }
+
+    helpers.log_message(`Showing fan entity ${entity_id}`, JSON.stringify(fan, null, 4));
+
+    // Helper function to get fan data
+    function getFanData(fan) {
+        let timeStr = helpers.humanDiff(new Date(), new Date(fan.last_changed));
+
+        let percentage = null;
+        if (fan.attributes.percentage !== undefined && fan.attributes.percentage !== null) {
+            percentage = Math.round(fan.attributes.percentage);
+        }
+
+        return {
+            entity_id: fan.entity_id,
+            friendly_name: fan.attributes.friendly_name || fan.entity_id,
+            state: fan.state,
+            is_on: fan.state === "on",
+            percentage: percentage,
+            percentage_step: fan.attributes.percentage_step || 10,
+            preset_mode: fan.attributes.preset_mode,
+            preset_modes: fan.attributes.preset_modes || [],
+            oscillating: fan.attributes.oscillating,
+            direction: fan.attributes.direction,
+            last_changed_time: timeStr
+        };
+    }
+
+    // Helper function to get supported features
+    function supported_features(entity) {
+        // Fan feature bitfield values from Home Assistant (FanEntityFeature enum)
+        const FanEntityFeature = {
+            SET_SPEED: 1,
+            OSCILLATE: 2,
+            DIRECTION: 4,
+            PRESET_MODE: 8,
+            TURN_OFF: 16,
+            TURN_ON: 32
+        };
+
+        const supported_features_value = entity.attributes.supported_features || 0;
+
+        let result = {
+            set_speed: !!(supported_features_value & FanEntityFeature.SET_SPEED),
+            oscillate: !!(supported_features_value & FanEntityFeature.OSCILLATE),
+            direction: !!(supported_features_value & FanEntityFeature.DIRECTION),
+            preset_mode: !!(supported_features_value & FanEntityFeature.PRESET_MODE)
+        };
+
+        helpers.log_message(`Fan ${entity.entity_id} supported features: ${JSON.stringify(result)}`);
+
+        return result;
+    }
+
+    // Get initial fan data
+    let fanData = getFanData(fan);
+    let features = supported_features(fan);
+
+    // Create the fan menu
+    let fanMenu = new UI.Menu({
+        status: false,
+        backgroundColor: 'black',
+        textColor: 'white',
+        highlightBackgroundColor: 'white',
+        highlightTextColor: 'black',
+        sections: [{
+            title: fanData.friendly_name
+        }]
+    });
+
+    // Function to update menu items based on current fan state
+    function updateFanMenuItems(updatedFan) {
+        // Get updated fan data
+        let updatedData = getFanData(updatedFan);
+        let menuIndex = 0;
+
+        // Update main status item
+        fanMenu.item(0, menuIndex++, {
+            title: updatedData.friendly_name,
+            subtitle: `${updatedData.is_on ? 'on' : 'off'} > ${updatedData.last_changed_time}`,
+            icon: updatedData.is_on ? 'images/icon_switch_on.png' : 'images/icon_switch_off.png',
+            on_click: function() {
+                // Toggle fan on/off
+                appState.haws.callService(
+                    "fan",
+                    "toggle",
+                    {},
+                    { entity_id: updatedData.entity_id },
+                    function(data) {
+                        Vibe.vibrate('short');
+                        helpers.log_message(`Toggled fan: ${updatedData.entity_id}`);
+                    },
+                    function(error) {
+                        Vibe.vibrate('double');
+                        helpers.log_message(`Error toggling fan: ${error}`);
+                    }
+                );
+            }
+        });
+
+        // Update speed item if supported
+        if (features.set_speed) {
+            fanMenu.item(0, menuIndex++, {
+                title: 'Speed',
+                subtitle: updatedData.is_on && updatedData.percentage !== null ? `${updatedData.percentage}%` : 'NA',
+                on_click: function() {
+                    showSpeedMenu(updatedData.entity_id, updatedData.percentage || 0, updatedData.percentage_step);
+                }
+            });
+        }
+
+        // Update preset mode item if supported
+        if (features.preset_mode && updatedData.preset_modes && updatedData.preset_modes.length > 0) {
+            fanMenu.item(0, menuIndex++, {
+                title: 'Preset',
+                subtitle: updatedData.preset_mode || 'None',
+                on_click: function() {
+                    showPresetModeMenu(updatedData.entity_id, updatedData.preset_mode, updatedData.preset_modes);
+                }
+            });
+        }
+
+        // Update oscillation item if supported
+        if (features.oscillate) {
+            fanMenu.item(0, menuIndex++, {
+                title: 'Oscillate',
+                subtitle: updatedData.oscillating ? 'On' : 'Off',
+                on_click: function() {
+                    appState.haws.callService(
+                        "fan",
+                        "oscillate",
+                        { oscillating: !updatedData.oscillating },
+                        { entity_id: updatedData.entity_id },
+                        function(data) {
+                            Vibe.vibrate('short');
+                            helpers.log_message(`Set oscillation to ${!updatedData.oscillating}`);
+                        },
+                        function(error) {
+                            Vibe.vibrate('double');
+                            helpers.log_message(`Error setting oscillation: ${error}`);
+                        }
+                    );
+                }
+            });
+        }
+
+        // Update direction item if supported
+        if (features.direction) {
+            fanMenu.item(0, menuIndex++, {
+                title: 'Direction',
+                subtitle: updatedData.direction ? helpers.ucwords(updatedData.direction) : 'Unknown',
+                on_click: function() {
+                    let newDirection = updatedData.direction === 'forward' ? 'reverse' : 'forward';
+                    appState.haws.callService(
+                        "fan",
+                        "set_direction",
+                        { direction: newDirection },
+                        { entity_id: updatedData.entity_id },
+                        function(data) {
+                            Vibe.vibrate('short');
+                            helpers.log_message(`Set direction to ${newDirection}`);
+                        },
+                        function(error) {
+                            Vibe.vibrate('double');
+                            helpers.log_message(`Error setting direction: ${error}`);
+                        }
+                    );
+                }
+            });
+        }
+
+        // Add More option
+        fanMenu.item(0, menuIndex++, {
+            title: 'More',
+            on_click: function() {
+                GenericEntityPage.showEntityMenu(updatedData.entity_id);
+            }
+        });
+    }
+
+    // Helper function to show speed selection menu
+    function showSpeedMenu(entity_id, current_percentage, percentage_step) {
+        // Remember which menu item we came from
+        let returnToIndex = selectedIndex;
+
+        // Steps for adjusting speed (percentage_step can be fractional, e.g. 33.33 for 3-speed fans)
+        let smallStep = percentage_step || 10;
+        let largeStep = Math.max(25, smallStep);
+
+        // Create a window for the speed slider
+        let speedWindow = new UI.Window({
+            backgroundColor: 'white',
+            status: {
+                color: 'black',
+                backgroundColor: 'white',
+                seperator: "dotted"
+            }
+        });
+
+        // Add title
+        let title = new UI.Text({
+            text: "Speed",
+            color: "black",
+            font: "gothic_24_bold",
+            position: new Vector(0, 0),
+            size: new Vector(Feature.resolution().x, 30),
+            textAlign: "center"
+        });
+
+        // Add current value text
+        let valueText = new UI.Text({
+            text: `${Math.round(current_percentage)}%`,
+            color: "black",
+            font: "gothic_24",
+            position: new Vector(0, 35),
+            size: new Vector(Feature.resolution().x, 30),
+            textAlign: "center"
+        });
+
+        // Add slider background
+        let sliderBg = new UI.Rect({
+            position: new Vector(20, 70),
+            size: new Vector(Feature.resolution().x - 40, 20),
+            backgroundColor: 'lightGray'
+        });
+
+        // Add slider foreground (progress)
+        let sliderWidth = Math.round((Feature.resolution().x - 40) * (current_percentage / 100));
+        let sliderFg = new UI.Rect({
+            position: new Vector(20, 70),
+            size: new Vector(sliderWidth, 20),
+            backgroundColor: 'black'
+        });
+
+        // Add instructions
+        let instructions = new UI.Text({
+            text: "UP/DOWN: Adjust | SELECT: Set",
+            color: "black",
+            font: "gothic_14",
+            position: new Vector(0, 100),
+            size: new Vector(Feature.resolution().x, 20),
+            textAlign: "center"
+        });
+
+        // Add elements to window
+        speedWindow.add(title);
+        speedWindow.add(valueText);
+        speedWindow.add(sliderBg);
+        speedWindow.add(sliderFg);
+        speedWindow.add(instructions);
+
+        // Handle button events
+        speedWindow.on('click', 'up', function() {
+            current_percentage = Math.min(100, current_percentage + smallStep);
+            updateSpeedUI();
+        });
+
+        speedWindow.on('click', 'down', function() {
+            current_percentage = Math.max(0, current_percentage - smallStep);
+            updateSpeedUI();
+        });
+
+        speedWindow.on('longClick', 'up', function() {
+            current_percentage = Math.min(100, current_percentage + largeStep);
+            updateSpeedUI();
+        });
+
+        speedWindow.on('longClick', 'down', function() {
+            current_percentage = Math.max(0, current_percentage - largeStep);
+            updateSpeedUI();
+        });
+
+        speedWindow.on('click', 'select', function() {
+            // Set the speed (fan.set_percentage with 0 turns the fan off)
+            appState.haws.callService(
+                "fan",
+                "set_percentage",
+                { percentage: Math.round(current_percentage) },
+                { entity_id: entity_id },
+                function(data) {
+                    Vibe.vibrate('short');
+                    helpers.log_message(`Set fan speed to ${Math.round(current_percentage)}%`);
+                    speedWindow.hide();
+                },
+                function(error) {
+                    Vibe.vibrate('double');
+                    helpers.log_message(`Error setting fan speed: ${error}`);
+                }
+            );
+        });
+
+        // Function to update the UI based on current speed
+        function updateSpeedUI() {
+            valueText.text(`${Math.round(current_percentage)}%`);
+            sliderWidth = Math.round((Feature.resolution().x - 40) * (current_percentage / 100));
+            sliderFg.size(new Vector(sliderWidth, 20));
+        }
+
+        // Subscribe to entity updates
+        let speed_subscription_msg_id = appState.haws.subscribeTrigger({
+            "type": "subscribe_trigger",
+            "trigger": {
+                "platform": "state",
+                "entity_id": entity_id,
+            },
+        }, function(data) {
+            helpers.log_message(`Fan entity update for speed menu ${entity_id}`);
+            if (data.event && data.event.variables && data.event.variables.trigger && data.event.variables.trigger.to_state) {
+                let updatedFan = data.event.variables.trigger.to_state;
+                appState.ha_state_dict[entity_id] = updatedFan;
+
+                let updatedData = getFanData(updatedFan);
+                if (updatedData.is_on && updatedData.percentage !== null) {
+                    current_percentage = updatedData.percentage;
+                    updateSpeedUI();
+                }
+            }
+        }, function(error) {
+            helpers.log_message(`ENTITY UPDATE ERROR [${entity_id}]: ${JSON.stringify(error)}`);
+        });
+
+        speedWindow.on('hide', function() {
+            // Unsubscribe from entity updates
+            if (speed_subscription_msg_id) {
+                appState.haws.unsubscribe(speed_subscription_msg_id);
+            }
+
+            // Restore the selection in the parent menu
+            selectedIndex = returnToIndex;
+        });
+
+        speedWindow.show();
+    }
+
+    // Helper function to show preset mode selection menu
+    function showPresetModeMenu(entity_id, current_mode, preset_modes) {
+        // Remember which menu item we came from
+        let returnToIndex = selectedIndex;
+
+        // Create preset mode selection menu
+        let presetMenu = new UI.Menu({
+            status: false,
+            backgroundColor: 'black',
+            textColor: 'white',
+            highlightBackgroundColor: 'white',
+            highlightTextColor: 'black',
+            sections: [{
+                title: 'Select Preset'
+            }]
+        });
+
+        // Add preset mode options to menu
+        for (let i = 0; i < preset_modes.length; i++) {
+            let mode = preset_modes[i];
+            let isCurrentMode = mode === current_mode;
+
+            presetMenu.item(0, i, {
+                title: mode,
+                subtitle: isCurrentMode ? 'Current' : '',
+                on_click: function() {
+                    appState.haws.callService(
+                        "fan",
+                        "set_preset_mode",
+                        { preset_mode: mode },
+                        { entity_id: entity_id },
+                        function(data) {
+                            Vibe.vibrate('short');
+                            helpers.log_message(`Set preset mode to ${mode}`);
+                        },
+                        function(error) {
+                            Vibe.vibrate('double');
+                            helpers.log_message(`Error setting preset mode: ${error}`);
+                        }
+                    );
+                }
+            });
+        }
+
+        // Helper function to update preset menu items
+        function updatePresetMenuItems(updatedFan) {
+            let updatedData = getFanData(updatedFan);
+
+            for (let i = 0; i < preset_modes.length; i++) {
+                let mode = preset_modes[i];
+                let isCurrentMode = mode === updatedData.preset_mode;
+
+                presetMenu.item(0, i, {
+                    title: mode,
+                    subtitle: isCurrentMode ? 'Current' : '',
+                    on_click: presetMenu.items(0)[i].on_click
+                });
+            }
+        }
+
+        // Subscribe to entity updates
+        let preset_subscription_msg_id = appState.haws.subscribeTrigger({
+            "type": "subscribe_trigger",
+            "trigger": {
+                "platform": "state",
+                "entity_id": entity_id,
+            },
+        }, function(data) {
+            helpers.log_message(`Fan entity update for preset menu ${entity_id}`);
+            if (data.event && data.event.variables && data.event.variables.trigger && data.event.variables.trigger.to_state) {
+                let updatedFan = data.event.variables.trigger.to_state;
+                appState.ha_state_dict[entity_id] = updatedFan;
+
+                // Update menu items directly
+                updatePresetMenuItems(updatedFan);
+            }
+        }, function(error) {
+            helpers.log_message(`ENTITY UPDATE ERROR [${entity_id}]: ${JSON.stringify(error)}`);
+        });
+
+        presetMenu.on('hide', function() {
+            // Unsubscribe from entity updates
+            if (preset_subscription_msg_id) {
+                appState.haws.unsubscribe(preset_subscription_msg_id);
+            }
+
+            // Restore the selection in the parent menu
+            selectedIndex = returnToIndex;
+        });
+
+        presetMenu.show();
+    }
+
+    // Track the selected index to restore it when returning from submenus
+    let selectedIndex = 0;
+
+    // Store the selected index when navigating to a submenu
+    fanMenu.on('select', function(e) {
+        // Store the current selection index
+        selectedIndex = e.itemIndex;
+        menuSelections.fanMenu = e.itemIndex;
+
+        helpers.log_message(`Fan menu item ${e.item.title} was selected! Index: ${selectedIndex}`);
+        if(typeof e.item.on_click === 'function') {
+            e.item.on_click(e);
+        }
+    });
+
+    // Set up event handlers for the fan menu
+    fanMenu.on('show', function() {
+        // Clear the menu
+        fanMenu.items(0, []);
+
+        // Get the latest fan data
+        fan = appState.ha_state_dict[entity_id];
+        fanData = getFanData(fan);
+        features = supported_features(fan);
+
+        // Update menu items
+        updateFanMenuItems(fan);
+
+        // Create RelativeTimeUpdater for live time updates
+        relativeTimeUpdater = new RelativeTimeUpdater(function(id, lastChanged) {
+            // Get current fan and update the menu
+            let currentFan = appState.ha_state_dict[entity_id];
+            if (currentFan) {
+                updateFanMenuItems(currentFan);
+            }
+        });
+        relativeTimeUpdater.register(entity_id, fan.last_changed);
+
+        // Subscribe to entity updates
+        subscription_msg_id = appState.haws.subscribeTrigger({
+            "type": "subscribe_trigger",
+            "trigger": {
+                "platform": "state",
+                "entity_id": entity_id,
+            },
+        }, function(data) {
+            helpers.log_message(`Fan entity update for ${entity_id}`);
+            if (data.event && data.event.variables && data.event.variables.trigger && data.event.variables.trigger.to_state) {
+                let updatedFan = data.event.variables.trigger.to_state;
+                appState.ha_state_dict[entity_id] = updatedFan;
+
+                // Update the menu items directly without redrawing the entire menu
+                updateFanMenuItems(updatedFan);
+
+                // Update the RelativeTimeUpdater with the new timestamp
+                if (relativeTimeUpdater) {
+                    relativeTimeUpdater.update(entity_id, updatedFan.last_changed);
+                }
+            }
+        }, function(error) {
+            helpers.log_message(`ENTITY UPDATE ERROR [${entity_id}]: ${JSON.stringify(error)}`);
+        });
+
+        // Restore the previously selected index
+        setTimeout(function() {
+            // First try to use the global menu selection
+            if (menuSelections.fanMenu > 0 && menuSelections.fanMenu < fanMenu.items(0).length) {
+                fanMenu.selection(0, menuSelections.fanMenu);
+                selectedIndex = menuSelections.fanMenu;
+            }
+            // Fall back to the local selectedIndex if needed
+            else if (selectedIndex > 0 && selectedIndex < fanMenu.items(0).length) {
+                fanMenu.selection(0, selectedIndex);
+            }
+        }, 100);
+    });
+
+    fanMenu.on('hide', function() {
+        // Unsubscribe from entity updates
+        if (subscription_msg_id) {
+            appState.haws.unsubscribe(subscription_msg_id);
+        }
+
+        // Destroy the RelativeTimeUpdater
+        if (relativeTimeUpdater) {
+            relativeTimeUpdater.destroy();
+            relativeTimeUpdater = null;
+        }
+    });
+
+    // Show the menu
+    fanMenu.show();
+}
+
+module.exports.showFanEntity = showFanEntity;

--- a/src/js/app/pages/entity/GenericEntityPage.js
+++ b/src/js/app/pages/entity/GenericEntityPage.js
@@ -153,7 +153,8 @@ function showEntityMenu(entity_id) {
         domain === "switch" ||
         domain === "input_boolean" ||
         domain === "automation" ||
-        domain === "script"
+        domain === "script" ||
+        domain === "fan"
     )
     {
         showEntityMenu.item(1, servicesCount++, { //menuIndex

--- a/src/js/app/pages/entity/GenericEntityPage.js
+++ b/src/js/app/pages/entity/GenericEntityPage.js
@@ -219,6 +219,49 @@ function showEntityMenu(entity_id) {
         });
     }
 
+    if(domain === "cover") {
+        // Cover feature bits from Home Assistant's CoverEntityFeature enum.
+        // cover.toggle is only registered for entities supporting OPEN and CLOSE
+        const sf = entity.attributes.supported_features || 0;
+        const canOpen = !!(sf & 1);   // OPEN
+        const canClose = !!(sf & 2);  // CLOSE
+        const canStop = !!(sf & 8);   // STOP
+
+        function coverServiceItem(title, service) {
+            return {
+                title: title,
+                on_click: function(){
+                    appState.haws.callService(
+                        domain,
+                        service,
+                        {},
+                        {entity_id: entity.entity_id},
+                        function(data) {
+                            Vibe.vibrate('short');
+                            helpers.log_message(JSON.stringify(data));
+                        },
+                        function(error) {
+                            Vibe.vibrate('double');
+                            helpers.log_message('no response');
+                        });
+                }
+            };
+        }
+
+        if (canOpen && canClose) {
+            showEntityMenu.item(1, servicesCount++, coverServiceItem('Toggle', 'toggle'));
+        }
+        if (canOpen) {
+            showEntityMenu.item(1, servicesCount++, coverServiceItem('Open', 'open_cover'));
+        }
+        if (canClose) {
+            showEntityMenu.item(1, servicesCount++, coverServiceItem('Close', 'close_cover'));
+        }
+        if (canStop) {
+            showEntityMenu.item(1, servicesCount++, coverServiceItem('Stop', 'stop_cover'));
+        }
+    }
+
     if(domain === "lock") {
         showEntityMenu.item(1, servicesCount++, { //menuIndex
             title: 'Lock',

--- a/src/js/app/pages/entity/MediaPlayerPage.js
+++ b/src/js/app/pages/entity/MediaPlayerPage.js
@@ -16,6 +16,7 @@ var Feature = require('platform/feature');
 
 var BaseEntityPage = require('app/pages/entity/BaseEntityPage');
 var AppState = require('app/AppState');
+var Constants = require('app/Constants');
 var helpers = require('app/helpers');
 
 // Feature constants

--- a/src/js/app/pages/entity/MediaPlayerPage.js
+++ b/src/js/app/pages/entity/MediaPlayerPage.js
@@ -135,7 +135,7 @@ class MediaPlayerPage extends BaseEntityPage {
 
         this.mediaName = new UI.Text({
             text: mediaPlayer.attributes.friendly_name,
-            color: Feature.color(appState.colour.highlight, "black"),
+            color: Feature.color(Constants.colour.highlight, "black"),
             font: titleFont,
             position: Feature.round(new Vector(10, titleY), new Vector(5, titleY)),
             size: new Vector(availableWidth, 30),

--- a/src/js/app/ui/MenuTheme.js
+++ b/src/js/app/ui/MenuTheme.js
@@ -1,0 +1,88 @@
+/**
+ * MenuTheme - resolves menu colors based on settings and sun position.
+ */
+
+var AppState = require('app/AppState');
+var Constants = require('app/Constants');
+var SunCalc = require('app/suncalc');
+
+var MenuTheme = {
+    getMode: function() {
+        var appState = AppState.getInstance();
+        var mode = appState.menu_background_mode;
+
+        if (mode === Constants.menuBackgroundModes.BLACK ||
+            mode === Constants.menuBackgroundModes.WHITE ||
+            mode === Constants.menuBackgroundModes.SUN) {
+            return mode;
+        }
+
+        return Constants.menuBackgroundModes.SUN;
+    },
+
+    getMenuColors: function() {
+        var backgroundColor = this._resolveBackgroundColor();
+        var isBlack = backgroundColor === 'black';
+
+        return {
+            backgroundColor: backgroundColor,
+            textColor: isBlack ? 'white' : 'black',
+            highlightBackgroundColor: isBlack ? 'white' : 'black',
+            highlightTextColor: isBlack ? 'black' : 'white'
+        };
+    },
+
+    applyToMenu: function(menu) {
+        if (!menu || !menu.state) {
+            return;
+        }
+
+        var colors = this.getMenuColors();
+        menu.state.backgroundColor = colors.backgroundColor;
+        menu.state.textColor = colors.textColor;
+        menu.state.highlightBackgroundColor = colors.highlightBackgroundColor;
+        menu.state.highlightTextColor = colors.highlightTextColor;
+
+        if (typeof menu._prop === 'function') {
+            menu._prop(menu.state);
+        }
+    },
+
+    _resolveBackgroundColor: function() {
+        var mode = this.getMode();
+
+        if (mode === Constants.menuBackgroundModes.BLACK) {
+            return 'black';
+        }
+
+        if (mode === Constants.menuBackgroundModes.WHITE) {
+            return 'white';
+        }
+
+        return this._resolveSunBasedBackground();
+    },
+
+    _resolveSunBasedBackground: function() {
+        var appState = AppState.getInstance();
+
+        if (appState.latitude === null || appState.latitude === undefined ||
+            appState.longitude === null || appState.longitude === undefined) {
+            return 'black';
+        }
+
+        var now = new Date();
+        var times = SunCalc.getTimes(now, appState.latitude, appState.longitude);
+        if (!times || !times.sunrise || !times.sunset) {
+            return 'black';
+        }
+
+        if (isNaN(times.sunrise.getTime()) || isNaN(times.sunset.getTime())) {
+            return 'black';
+        }
+
+        var isDay = now >= times.sunrise && now < times.sunset;
+        return isDay ? 'white' : 'black';
+    }
+};
+
+module.exports = MenuTheme;

--- a/src/js/settings/settings.js
+++ b/src/js/settings/settings.js
@@ -66,6 +66,13 @@ Settings._getDataKey = function(path, field) {
   return field + ':' + path;
 };
 
+// Backup key carries the previous good value so a torn primary write
+// (e.g. JS process killed mid-setItem) doesn't strand the user with no
+// recoverable settings.
+Settings._getBackupKey = function(path, field) {
+  return Settings._getDataKey(path, field) + '.bak';
+};
+
 Settings._saveData = function(path, field, data) {
   field = field || 'data';
   if (data) {
@@ -74,18 +81,40 @@ Settings._saveData = function(path, field, data) {
     data = state[field];
   }
   var key = Settings._getDataKey(path, field);
-  localStorage.setItem(key, JSON.stringify(data));
+  var backupKey = Settings._getBackupKey(path, field);
+  var serialized;
+  try {
+    serialized = JSON.stringify(data);
+  } catch (e) {
+    safe.warn('Failed to serialize settings for ' + key + ': ' + (e.message || e));
+    return;
+  }
+  // Promote the current primary to backup before overwriting it, so we always
+  // have at least one parseable copy on disk.
+  var previous = localStorage.getItem(key);
+  if (previous && previous !== serialized) {
+    localStorage.setItem(backupKey, previous);
+  }
+  localStorage.setItem(key, serialized);
 };
 
 Settings._loadData = function(path, field, nocache) {
   field = field || 'data';
   state[field] = {};
   var key = Settings._getDataKey(path, field);
+  var backupKey = Settings._getBackupKey(path, field);
   var value = localStorage.getItem(key);
   var data = parseJson(value);
   if (value && typeof data === 'undefined') {
-    // There was an issue loading the data, remove it
-    localStorage.removeItem(key);
+    // Primary is corrupt (likely a torn write). Try the backup before giving
+    // up — and never remove the primary, so the raw bytes remain available
+    // for manual recovery / debugging on next launch.
+    safe.warn('Primary settings for ' + key + ' did not parse; trying backup.');
+    var backupValue = localStorage.getItem(backupKey);
+    var backupData = parseJson(backupValue);
+    if (backupValue && typeof backupData !== 'undefined') {
+      data = backupData;
+    }
   }
   if (!nocache && typeof data === 'object' && data !== null) {
     state[field] = data;

--- a/src/js/ui/menu.js
+++ b/src/js/ui/menu.js
@@ -12,6 +12,7 @@ var defaults = {
   textColor: 'black',
   highlightBackgroundColor: 'black',
   highlightTextColor: 'white',
+  scrollWrap: true,
 };
 
 var Menu = function(menuDef) {
@@ -23,6 +24,12 @@ var Menu = function(menuDef) {
 };
 
 Menu._codeName = 'menu';
+
+// Sets the default wrap-around scrolling behavior for menus created afterwards.
+// Menus that explicitly pass scrollWrap in their definition are unaffected.
+Menu.setScrollWrapDefault = function(enabled) {
+  defaults.scrollWrap = (enabled !== false);
+};
 
 util2.inherit(Menu, Window);
 
@@ -158,18 +165,18 @@ Menu.prototype._resolveMenu = function(clear, pushing) {
   }
 };
 
-Menu.prototype._resolveSection = function(e, clear) {
+Menu.prototype._resolveSection = function(e, clear, skipPreload) {
   var section = this._getSection(e);
   if (!section) { return; }
   section = myutil.shadow({
-    textColor: this.state.textColor, 
+    textColor: this.state.textColor,
     backgroundColor: this.state.backgroundColor
   }, section);
   section.items = this._getItems(e);
   if (this === WindowStack.top()) {
     simply.impl.menuSection.call(this, e.sectionIndex, section, clear);
     var select = this._selection;
-    if (select.sectionIndex === e.sectionIndex) {
+    if (!skipPreload && select.sectionIndex === e.sectionIndex) {
       this._preloadItems(select);
     }
     return true;
@@ -308,7 +315,10 @@ Menu.prototype.item = function(sectionIndex, itemIndex, item) {
   var prevLength = items.length;
   items[itemIndex] = util2.copy(item, items[itemIndex]);
   if (items.length !== prevLength) {
-    this._resolveSection(menuIndex);
+    // The appended item is sent by _resolveItem below, so skip the preload
+    // pass. Preloading here re-sends every cached item on each append,
+    // flooding the message queue with O(N^2) packets while building a menu.
+    this._resolveSection(menuIndex, undefined, true);
   }
   this._resolveItem(menuIndex);
   return this;

--- a/src/js/ui/simply-pebble.js
+++ b/src/js/ui/simply-pebble.js
@@ -1545,6 +1545,10 @@ SimplyPebble.onAccelData = function(packet) {
   }
 };
 
+// Set by the app to be notified of direct user input on the watch (e.g. to
+// drive an inactivity timeout). Called with no arguments.
+SimplyPebble.onUserActivity = null;
+
 SimplyPebble.onPacket = function(buffer, offset) {
   Packet._view = buffer;
   Packet._offset = offset;
@@ -1557,6 +1561,25 @@ SimplyPebble.onPacket = function(buffer, offset) {
 
   packet._view = Packet._view;
   packet._offset = offset;
+
+  // These packets only arrive as a result of the user physically interacting
+  // with the watch. Data requests (MenuGetItem etc) are excluded: those are
+  // rendering-driven and would keep the app alive without any user present.
+  switch (packet) {
+    case ClickPacket:
+    case LongClickPacket:
+    case AccelTapPacket:
+    case MenuSelectPacket:
+    case MenuLongSelectPacket:
+    case MenuSelectionEventPacket:
+    case WindowHideEventPacket:
+    case VoiceDictationDataPacket:
+      if (SimplyPebble.onUserActivity) {
+        SimplyPebble.onUserActivity();
+      }
+      break;
+  }
+
   switch (packet) {
     case LaunchReasonPacket:
       SimplyPebble.onLaunchReason(packet);

--- a/src/js/ui/simply-pebble.js
+++ b/src/js/ui/simply-pebble.js
@@ -571,6 +571,7 @@ var MenuPropsPacket = new struct([
   ['uint8', 'textColor', ColorType],
   ['uint8', 'highlightBackgroundColor', ColorType],
   ['uint8', 'highlightTextColor', ColorType],
+  ['bool', 'scrollWrap', BoolType],
 ]);
 
 var MenuSectionPacket = new struct([
@@ -1216,7 +1217,9 @@ SimplyPebble.menuClearSection = function(section) {
 };
 
 SimplyPebble.menuProps = function(def) {
-  SimplyPebble.sendPacket(MenuPropsPacket.prop(def));
+  // scrollWrap is set explicitly because the packet buffer is reused between
+  // sends and prop() skips fields missing from def
+  SimplyPebble.sendPacket(MenuPropsPacket.prop(def).scrollWrap(def.scrollWrap !== false));
 };
 
 SimplyPebble.menuSection = function(section, def, clear) {

--- a/src/js/vendor/haws.js
+++ b/src/js/vendor/haws.js
@@ -24,6 +24,22 @@ class HAWS {
         return this.connected;
     }
 
+    /**
+     * Build a human-readable description of a WebSocket CloseEvent.
+     * The native onclose event is a CloseEvent (code/reason/wasClean),
+     * NOT a CustomEvent, so evt.detail is always undefined.
+     */
+    static _describeCloseEvent(evt) {
+        if (!evt || typeof evt.code === 'undefined') {
+            // Not a standard CloseEvent - dump whatever we got so it isn't just "undefined"
+            return JSON.stringify(evt, null, 4);
+        }
+
+        let meaning = HAWS.CLOSE_CODES[evt.code] || 'Unknown close code';
+        let reason = evt.reason ? ` reason="${evt.reason}"` : '';
+        return `code=${evt.code} (${meaning})${reason} wasClean=${!!evt.wasClean}`;
+    }
+
     connect() {
         if(this.connected) {
             return false;
@@ -33,10 +49,10 @@ class HAWS {
             ws_url = this.ha_url.replace('http','ws').replace(/\/+$/, '') + '/api/websocket';
         this.ws = new WebSocket(ws_url);
         this.ws.onclose = (evt) => {
-            that.events.dispatchEvent(new CustomEvent("close", {detail: evt.detail}));
+            that.events.dispatchEvent(new CustomEvent("close", {detail: evt}));
             this.connected = false;
             if (!this.selfDisconnect) {
-                console.log(`[HAWS] WebSocket closed: ${JSON.stringify(evt.detail, null, 4)}`);
+                console.log(`[HAWS] WebSocket closed: ${HAWS._describeCloseEvent(evt)}`);
                 this.startAttemptingToEstablishConnection();
             }
         }
@@ -581,5 +597,27 @@ class HAWS {
         return subscriptionId;
     }
 }
+
+/**
+ * Standard WebSocket close codes (RFC 6455) plus common reasons,
+ * used to turn an opaque close code into something actionable in the logs.
+ */
+HAWS.CLOSE_CODES = {
+    1000: 'Normal closure',
+    1001: 'Going away (server shutting down or browser navigating away)',
+    1002: 'Protocol error',
+    1003: 'Unsupported data',
+    1005: 'No status received (connection closed without a close frame - often network drop or wrong URL/port)',
+    1006: 'Abnormal closure (connection failed - check HA URL, that HA is reachable, and TLS/SSL settings)',
+    1007: 'Invalid frame payload data',
+    1008: 'Policy violation',
+    1009: 'Message too big',
+    1010: 'Missing extension',
+    1011: 'Internal server error',
+    1012: 'Service restart',
+    1013: 'Try again later',
+    1014: 'Bad gateway',
+    1015: 'TLS handshake failure (HTTPS/SSL problem - verify the certificate and that the URL scheme matches)'
+};
 
 module.exports = HAWS;

--- a/src/simply/simply_menu.c
+++ b/src/simply/simply_menu.c
@@ -326,6 +326,17 @@ static MenuIndex simply_menu_get_selection(SimplyMenu *self) {
 
 static void simply_menu_set_selection(SimplyMenu *self, MenuIndex menu_index, MenuRowAlign align,
                                       bool animated) {
+  if (!self->menu_layer.menu_layer) { return; }
+  // Apply any pending debounced reload before selecting. The selection packet
+  // usually arrives in the same message batch as the section data it refers
+  // to, and the MenuLayer computes the scroll offset from the row counts it
+  // currently knows: selecting against stale counts restores the highlight
+  // but leaves the list scrolled to the top with the selection off screen.
+  if (self->reload_timer) {
+    app_timer_cancel(self->reload_timer);
+    self->reload_timer = NULL;
+    prv_reload_data(self);
+  }
   menu_layer_set_selected_index(self->menu_layer.menu_layer, menu_index, align, animated);
 }
 

--- a/src/simply/simply_menu.c
+++ b/src/simply/simply_menu.c
@@ -53,6 +53,7 @@ struct __attribute__((__packed__)) MenuPropsPacket {
   GColor8 text_color;
   GColor8 highlight_background_color;
   GColor8 highlight_text_color;
+  bool scroll_wrap;
 };
 
 typedef struct MenuSectionPacket MenuSectionPacket;
@@ -1026,9 +1027,74 @@ static void prv_single_click_handler(ClickRecognizerRef recognizer, void *contex
   simply_window_single_click_handler(recognizer, window);
 }
 
+static uint16_t prv_get_section_num_rows(SimplyMenu *self, uint16_t section_index) {
+  // Mirrors prv_menu_get_num_rows_callback: sections not yet loaded report 1 row
+  SimplyMenuSection *section = prv_get_menu_section(self, section_index);
+  return section ? section->num_items : 1;
+}
+
+// Returns true and fills target_out when the selection sits at the first (up) or
+// last (down) selectable row and there is a different row to wrap to.
+static bool prv_get_wrap_target(SimplyMenu *self, bool up, MenuIndex index,
+                                MenuIndex *target_out) {
+  const uint16_t num_sections = self->menu_layer.num_sections;
+  if (up) {
+    if (index.row > 0) { return false; }
+    for (int32_t s = (int32_t)index.section - 1; s >= 0; --s) {
+      if (prv_get_section_num_rows(self, s) > 0) { return false; }
+    }
+    for (int32_t s = (int32_t)num_sections - 1; s >= 0; --s) {
+      const uint16_t num_rows = prv_get_section_num_rows(self, s);
+      if (num_rows > 0) {
+        *target_out = (MenuIndex) { .section = s, .row = num_rows - 1 };
+        return (target_out->section != index.section || target_out->row != index.row);
+      }
+    }
+  } else {
+    if (index.row + 1 < prv_get_section_num_rows(self, index.section)) { return false; }
+    for (uint16_t s = index.section + 1; s < num_sections; ++s) {
+      if (prv_get_section_num_rows(self, s) > 0) { return false; }
+    }
+    for (uint16_t s = 0; s < num_sections; ++s) {
+      if (prv_get_section_num_rows(self, s) > 0) {
+        *target_out = (MenuIndex) { .section = s, .row = 0 };
+        return (target_out->section != index.section || target_out->row != index.row);
+      }
+    }
+  }
+  return false;
+}
+
+static void prv_up_down_click_handler(ClickRecognizerRef recognizer, void *context) {
+  MenuLayer *menu_layer = context;
+  Window *base_window = layer_get_window(menu_layer_get_layer(menu_layer));
+  SimplyMenu *self = window_get_user_data(base_window);
+  const bool up = (click_recognizer_get_button_id(recognizer) == BUTTON_ID_UP);
+
+#if !defined(PBL_PLATFORM_APLITE)
+  // Update last input time and clear idle state
+  self->last_input_time = time(NULL);
+  self->scroll_idle = false;
+#endif
+
+  // Wrap around only on a discrete press, never while the button is held down
+  // repeating, so holding a button stops at the edge instead of cycling forever
+  MenuIndex target;
+  if (self->menu_layer.scroll_wrap && click_number_of_clicks_counted(recognizer) <= 1 &&
+      prv_get_wrap_target(self, up, menu_layer_get_selected_index(menu_layer), &target)) {
+    menu_layer_set_selected_index(menu_layer, target, MenuRowAlignCenter, false);
+    return;
+  }
+
+  menu_layer_set_selected_next(menu_layer, up, MenuRowAlignCenter, true);
+}
+
 static void prv_click_config_provider(void *context) {
   window_single_click_subscribe(BUTTON_ID_BACK, prv_single_click_handler);
   menu_layer_click_config(context);
+  // Take over up/down so we can wrap the selection at the top and bottom
+  window_single_repeating_click_subscribe(BUTTON_ID_UP, 100, prv_up_down_click_handler);
+  window_single_repeating_click_subscribe(BUTTON_ID_DOWN, 100, prv_up_down_click_handler);
 }
 
 static void prv_menu_window_load(Window *window) {
@@ -1166,6 +1232,7 @@ static void prv_handle_menu_props_packet(Simply *simply, Packet *data) {
   MenuPropsPacket *packet = (MenuPropsPacket *)data;
   SimplyMenu *self = simply->menu;
 
+  self->menu_layer.scroll_wrap = packet->scroll_wrap;
   simply_menu_set_num_sections(self, packet->num_sections);
 
   if (!self->window.window) { return; }
@@ -1263,6 +1330,7 @@ SimplyMenu *simply_menu_create(Simply *simply) {
     .window.status_bar_insets_bottom = true,
 #endif
     .menu_layer.num_sections = 1,
+    .menu_layer.scroll_wrap = true,
     .reload_timer = NULL,
 #if !defined(PBL_PLATFORM_APLITE)
     .scroll_timer = NULL,

--- a/src/simply/simply_menu.h
+++ b/src/simply/simply_menu.h
@@ -28,6 +28,7 @@ struct SimplyMenuLayer {
   List1Node *sections;
   List1Node *items;
   uint16_t num_sections;
+  bool scroll_wrap;
   GColor8 normal_foreground;
   GColor8 normal_background;
   GColor8 highlight_foreground;


### PR DESCRIPTION
## Summary

A follow-up to v2.0 that adds fan and cover entity support, menu wrap-around scrolling, and an optional inactivity timeout, alongside scene and media player bug fixes, expanded long-press support, faster menu loading, and improvements to settings durability and connection diagnostics.

---

### Fixes
- **Scenes now activate on long-press**
  Long-pressing a scene was calling the `apply` service instead of
  `turn_on`, so scenes weren't being activated. It now calls `turn_on`.
  Thanks @chr1shaefn3r!
  Closes #71

- **Media player details page opens again**
  The media player details page referenced a non-existent
  `appState.colour.highlight` variable and failed to open. It now uses
  `Constants.colour.highlight`.
  Thanks @clemenstyp!

- **Returning to a menu restores your place**                                                                                                                                                                                     
  Pressing back to return to a previous menu kept the correct item                                                                                                                                                                
  selected, but the list stayed scrolled to the top (leaving the                                                                                                                                                                 
  selection off screen). The watch now applies pending menu data before                                                                                                                                                            
  restoring the selection, so the list scrolls back to the item you were                                                                                                                                                          
  on.

### Features
- **Long-press support for buttons**
  `button` and `input_button` entities now trigger their `press` service
  on long-press.
  Thanks @gausie!

- **Fan entity support**                                                                                                                                                                                                          
  Fans previously couldn't be controlled from the watch. Tapping a fan's                                                                                                                                                         
  state did nothing. Fans now have their own control page with on/off                                                                                                                                                             
  toggle, speed slider (respecting the fan's speed steps), preset modes,                                                                                                                                                          
  oscillation, and direction. Fans can also be toggled via long-press                                                                                                                                                             
  from entity lists, and show an on/off icon like switches.                                                                                                                                                                       
  Thanks @progfou for the report!                                                                                                                                                                                                 
  Closes #85

- **Menu scrolling wraps around**                                                                                                                                                                                                 
  Pressing up on the first item of a menu now jumps to the last item, and                                                                                                                                                         
  pressing down on the last item jumps back to the top. Holding a button                                                                                                                                                          
  still stops at the edge instead of cycling forever. Controlled by a new                                                                                                                                                         
  "Menu Scrolling - Wrap Around" toggle in the config page (enabled by                                                                                                                                                            
  default).                                                                                                                                                                                                                       
  Thanks @Phoenix616 for the suggestion!                                                                                                                                                                                          
  Closes #76

- **Optional inactivity timeout**                                                                                                                                                                                                 
  The app can now exit itself after a configurable period with no button                                                                                                                                                          
  presses or navigation on the watch. Handy for quick launch and voice                                                                                                                                                           
  command use. Set it in seconds from the config page, or pick a preset                                                                                                                                                           
  (30s to 1h) on the watch under Settings > Inactivity Timeout. Any                                                                                                                                                               
  interaction resets the countdown. Disabled by default.                                                                                                                                                                          
  Thanks @JunderscoreB for the suggestion!                                                                                                                                                                                        
  Closes #73

- **Cover entity support**                                                                                                                                                                                                        
  Covers (blinds, shades, garage doors, etc) now have their own control                                                                                                                                                           
  page with open/close/stop, a position slider, and tilt controls                                                                                                                                                                 
  (open/close/stop tilt and tilt position). Every control is shown only                                                                                                                                                           
  when the cover actually supports it, based on its supported features.                                                                                                                                                           
  Covers can also be toggled via long-press from entity lists.                                                                                                                                                                    
  Closes #15

### Improvements
- **Settings are backed up before every write**
  If the app closed or crashed while writing to localStorage, settings
  could be wiped. The previous good value is now snapshotted before each
  write and restored automatically if a write is torn, so settings
  survive crashes and unexpected exits.

- **Readable WebSocket disconnect logs**
  Disconnects previously logged `undefined`. Close events are now decoded
  into human-readable RFC 6455 reasons (e.g. abnormal closure, TLS
  handshake failure), making connectivity problems far easier to diagnose
  (#65).

- **Menus load much faster**                                                                                                                                                                                                      
  Building a menu previously re-sent every already-transferred item each                                                                                                                                                          
  time a new one was added, flooding the watch with duplicate packets.                                                                                                                                                            
  Menus now stream each item once and send the final item count up front,                                                                                                                                                         
  so long lists appear faster and wrap-around always knows the true end                                                                                                                                                           
  of the list.                                                                                                                                                                                                                    
                                                                                                                                                                                                                                  
- **Paging through entity lists starts at the top**                                                                                                                                                                               
  Selecting "Next Page" or "Prev Page" in an entity list now resets the                                                                                                                                                           
  selection to the top of the new page instead of staying at the bottom.

---

### Thanks
Big thanks to everyone who contributed to this release:
- @chr1shaefn3r — scene long-press fix
- @clemenstyp — media player details fix
- @gausie — long-press button support
- @Phoenix616 — menu wrap-around suggestion
- @progfou — fan support report and testing
- @JunderscoreB & @TiZ-HugLife— inactivity timeout suggestion